### PR TITLE
Fix consumes and produces annotations

### DIFF
--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ConsumesMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ConsumesMapper.java
@@ -33,17 +33,24 @@ import java.util.List;
  * @since 1.0
  */
 public class ConsumesMapper implements NamedAnnotationMapper {
+
+    private static final String[] JAX_RS_DEFAULT_VALUE = new String[] { "*/*" };
+
     @Nonnull
     @Override
     public String getName() {
-        return "javax.ws.rs.ConsumesMapper";
+        return "javax.ws.rs.Consumes";
     }
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
 
         final AnnotationValueBuilder<Consumes> builder = AnnotationValue.builder(Consumes.class);
-        annotation.stringValue().ifPresent(builder::value);
+        if (annotation.stringValues().length > 0) {
+            builder.values(annotation.stringValues());
+        } else {
+            builder.values(JAX_RS_DEFAULT_VALUE);
+        }
         return Collections.singletonList(
                 builder.build()
         );

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ProducesMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ProducesMapper.java
@@ -33,6 +33,9 @@ import java.util.List;
  * @since 1.0
  */
 public class ProducesMapper implements NamedAnnotationMapper {
+
+    private static final String[] JAX_RS_DEFAULT_VALUE = new String[] { "*/*" };
+
     @Nonnull
     @Override
     public String getName() {
@@ -43,7 +46,11 @@ public class ProducesMapper implements NamedAnnotationMapper {
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
 
         final AnnotationValueBuilder<Produces> builder = AnnotationValue.builder(Produces.class);
-        annotation.stringValue().ifPresent(builder::value);
+        if (annotation.stringValues().length > 0) {
+            builder.values(annotation.stringValues());
+        } else {
+            builder.values(JAX_RS_DEFAULT_VALUE);
+        }
         return Collections.singletonList(
                 builder.build()
         );

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/MediaTypeAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/MediaTypeAnnotationSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.jaxrs.processor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.http.annotation.Consumes
+import io.micronaut.http.annotation.Produces
+
+class MediaTypeAnnotationSpec extends AbstractTypeElementSpec {
+
+    void "test that values are set for produces and consumes #source"() {
+        given:
+            def definition = buildBeanDefinition('test.Test', """
+package test;
+
+@javax.ws.rs.Path("/test")
+class Test {
+
+    @javax.ws.rs.GET
+    @javax.ws.rs.Consumes($source)
+    @javax.ws.rs.Produces($source)
+    void test(@javax.ws.rs.PathParam("test") String test) {}
+}
+""")
+
+            def method = definition.getRequiredMethod("test", String)
+            def metadata = method.annotationMetadata
+
+        expect:
+            metadata.findAnnotation(Produces).get().values['value'] == value
+            metadata.findAnnotation(Consumes).get().values['value'] == value
+
+        where:
+            source                                 | value
+            '{ "application/json", "text/plain" }' | ["application/json", "text/plain"]
+            '{ "application/json" }'               | ["application/json"]
+            '"application/json"'                   | ["application/json"]
+            ''                                     | ["*/*"]
+    }
+
+}

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
@@ -69,7 +69,6 @@ class Test {
         metadata.stringValue(Bindable, "defaultValue").get() == 'foo'
     }
 
-
     @Unroll
     void "test unsupported parameter annotation #source"() {
         when:


### PR DESCRIPTION
I noticed that `javax.ws.rs.Produces` and `javax.ws.rs.Consumes` annotations are not mapped correctly. This is a fix for it.

Also `javax.ws.rs.Produces` and `javax.ws.rs.Consumes` have different default value: `*/*` while Micronaut has `application/json`. But I did not change that, I am not sure if it makes sense to handle that and what is the behaviour when applying `*/*` to Micronaut.