### PR TITLE
Workaround @PathParam value compiler issue

### DIFF
--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
@@ -15,16 +15,19 @@
  */
 package io.micronaut.jaxrs.processor;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
-
-import javax.annotation.Nonnull;
-import java.lang.annotation.Annotation;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Maps the JAX-RS {@code PathParam} annotation.
@@ -42,10 +45,17 @@ public class PathParamMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
 
-        final AnnotationValueBuilder<PathVariable> builder = AnnotationValue.builder(PathVariable.class);
-        annotation.stringValue().ifPresent(builder::value);
-        return Collections.singletonList(
-                builder.build()
+        final Optional<String> annotationValue = annotation.stringValue();
+        if (!annotationValue.isPresent()) {
+            return Collections.singletonList(
+                    AnnotationValue.builder(PathVariable.class).build()
+            );
+        }
+
+        final String value = annotationValue.get();
+        return Arrays.asList(
+                AnnotationValue.builder(PathVariable.class).value(value).build(),
+                AnnotationValue.builder(Bindable.class).value(value).build()
         );
     }
 }

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
@@ -93,4 +93,48 @@ class Test {
         MatrixParam | "test"
         BeanParam   | null
     }
+
+    void "test javax.ws.rs.PathParam value"() {
+        when:
+        def definition =  buildBeanDefinition('test.Test', """
+package test;
+
+@javax.ws.rs.Path("/test/{user_id}/v1")
+class Test {
+
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.PathParam("user_id") String userId) {}
+}
+""")
+
+        def method = definition.getRequiredMethod("test", String)
+        def metadata = method.arguments[0].getAnnotationMetadata()
+
+
+        then:
+        metadata.stringValue(Bindable, "value").get() == 'user_id'
+    }
+
+    void "test javax.ws.rs.PathParam value with javax.ws.rs.DefaultValue"() {
+        when:
+        def definition =  buildBeanDefinition('test.Test', """
+package test;
+
+@javax.ws.rs.Path("/test/{user_id}")
+class Test {
+
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.DefaultValue("foo") @javax.ws.rs.PathParam("user_id") String userId) {}
+}
+""")
+
+        def method = definition.getRequiredMethod("test", String)
+        def metadata = method.arguments[0].getAnnotationMetadata()
+
+
+        then:
+        metadata.stringValue(Bindable, "value").get() == 'user_id'
+        metadata.stringValue(Bindable, "defaultValue").get() == 'foo'
+    }
+
 }

--- a/jaxrs-server/build.gradle
+++ b/jaxrs-server/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 
 	// for Java
 	testAnnotationProcessor "io.micronaut:micronaut-inject-java"
+	testAnnotationProcessor "io.micronaut:micronaut-validation"
 	testAnnotationProcessor project(":jaxrs-processor")
 
 	// for Groovy

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/NotificationClient.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/NotificationClient.java
@@ -6,7 +6,6 @@ import io.micronaut.http.client.annotation.Client;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 @Client("/api/notifications")
 public interface NotificationClient {
@@ -18,6 +17,15 @@ public interface NotificationClient {
     @Path("/get/{id}")
     @Consumes(MediaType.APPLICATION_JSON)
     Notification getNotification(@PathParam("id") int id);
+
+    /**
+     * PathParam annotation has value `newId` equal to path variable `newId`,
+     * but variable `int id` is not equal to path variable `newId`
+     */
+    @GET
+    @Path("/get/v2/{newId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Notification getNotificationV2(@PathParam("newId") int id);
 
     @GET
     @Path("/query")

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/NotificationsResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/NotificationsResource.java
@@ -38,6 +38,19 @@ public class NotificationsResource {
                 .build();
     }
 
+    /**
+     * PathParam annotation has value `newId` equal to path variable `newId`,
+     * but variable `int id` is not equal to path variable `newId`
+     */
+    @GET
+    @Path("/get/v2/{newId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getNotificationV2(@Min(1) @PathParam("newId") int id) {
+        return Response.ok()
+                .entity(new Notification(id, "john", "test notification"))
+                .build();
+    }
+
     @GET
     @Path("/query")
     @Produces(MediaType.APPLICATION_JSON)

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/ResponseTest.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/ResponseTest.java
@@ -41,7 +41,15 @@ public class ResponseTest {
         assertNotNull(notification);
 
         assertEquals("john", notification.getName());
+    }
 
+    @Test
+    void testGetResponseV2() {
+        final Notification notification = client.getNotificationV2(10);
+
+        assertNotNull(notification);
+
+        assertEquals("john", notification.getName());
     }
 
     @Test


### PR DESCRIPTION
This workarounds compile issue with `@PathParam` reported in #45. Basically mapper also applies `@Bindable` with parameter name now.

To properly fix this, fix is needed in micronaut-core.