### PR TITLE
Fix Path parameter validation

### DIFF
--- a/jaxrs-processor/build.gradle
+++ b/jaxrs-processor/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	implementation 'org.jboss.resteasy:jaxrs-api:3.0.12.Final'
 
 	testImplementation "io.micronaut:micronaut-inject-java-test"
+	testAnnotationProcessor "io.micronaut:micronaut-validation:$micronautVersion"
 	testImplementation "io.micronaut:micronaut-validation:$micronautVersion"
 	if (!JavaVersion.current().isJava9Compatible()) {
 		testImplementation files(org.gradle.internal.jvm.Jvm.current().toolsJar)

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
@@ -16,15 +16,13 @@
 package io.micronaut.jaxrs.processor;
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import javax.annotation.Nonnull;
 
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -36,6 +34,7 @@ import io.micronaut.inject.visitor.VisitorContext;
  * @since 1.0
  */
 public class PathParamMapper implements NamedAnnotationMapper {
+
     @Nonnull
     @Override
     public String getName() {
@@ -45,17 +44,10 @@ public class PathParamMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
 
-        final Optional<String> annotationValue = annotation.stringValue();
-        if (!annotationValue.isPresent()) {
-            return Collections.singletonList(
-                    AnnotationValue.builder(PathVariable.class).build()
-            );
-        }
-
-        final String value = annotationValue.get();
-        return Arrays.asList(
-                AnnotationValue.builder(PathVariable.class).value(value).build(),
-                AnnotationValue.builder(Bindable.class).value(value).build()
+        final AnnotationValueBuilder<PathVariable> builder = AnnotationValue.builder(PathVariable.class);
+        annotation.stringValue().ifPresent(builder::value);
+        return Collections.singletonList(
+                builder.build()
         );
     }
 }

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
@@ -157,6 +157,33 @@ class Test {
 
     }
 
+    void "test mapping no path specified with @Controller"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', """
+package test;
+
+@io.micronaut.http.annotation.Controller("/test")
+class Test {
+
+    @javax.ws.rs.GET
+    @javax.ws.rs.Produces("text/plain")
+    String test() {
+        return "ok";
+    }
+}
+""")
+
+        def method = definition.getRequiredMethod("test")
+
+        expect:
+        method.hasAnnotation(Get)
+        method.stringValue(HttpMethodMapping)
+                .get() == '/'
+        method.stringValue(Produces)
+                .get() == 'text/plain'
+
+    }
+
 
     void "test mapping with validation"() {
         given:

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterAnnotationSpec.groovy
@@ -94,6 +94,30 @@ class Test {
         BeanParam   | null
     }
 
+    @Unroll
+    void "test unsupported parameter annotation #source with @Controller"() {
+        when:
+        buildBeanDefinition('test.Test', """
+package test;
+
+@io.micronaut.http.annotation.Controller("/test")
+class Test {
+
+    @javax.ws.rs.GET
+    void test(@$source.name(${value ? "\"$value\"" : ""}) String test) {}
+}
+""")
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("Unsupported JAX-RS annotation used on method: $source.name")
+
+        where:
+        source      | value
+        MatrixParam | "test"
+        BeanParam   | null
+    }
+
     void "test javax.ws.rs.PathParam value"() {
         when:
         def definition =  buildBeanDefinition('test.Test', """
@@ -133,7 +157,7 @@ class Test {
 
 
         then:
-        metadata.stringValue(Bindable, "value").get() == 'user_id'
+        metadata.stringValue(PathVariable, "value").get() == 'user_id'
         metadata.stringValue(Bindable, "defaultValue").get() == 'foo'
     }
 

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterValidationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/ParameterValidationSpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.jaxrs.processor
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+
+class ParameterValidationSpec extends AbstractTypeElementSpec {
+
+    void "test javax.ws.rs.PathParam path compile-time validation fails"() {
+        when:
+        buildBeanDefinition('test.Test', """
+package test;
+
+@javax.ws.rs.Path("/test")
+class Test {
+
+    @javax.ws.rs.Path("/{user_id}")
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.PathParam("u") String userId) {}
+}
+""")
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.message.contains("The route declares a uri variable named [user_id], but no corresponding method argument is present")
+
+        when:
+        buildBeanDefinition('test.Test', """
+package test;
+
+@io.micronaut.http.annotation.Controller("/test")
+class Test {
+
+    @javax.ws.rs.Path("/{user_id}")
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.PathParam("u") String userId) {}
+}
+""")
+
+        then:
+        ex = thrown(RuntimeException)
+        ex.message.contains("The route declares a uri variable named [user_id], but no corresponding method argument is present")
+    }
+
+    void "test javax.ws.rs.PathParam path compile-time validation passes"() {
+        when:
+        buildBeanDefinition('test.Test', """
+package test;
+
+@javax.ws.rs.Path("/test")
+class Test {
+
+    @javax.ws.rs.Path("/{user_id}")
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.PathParam("user_id") String userId) {}
+}
+""")
+
+        then:
+        noExceptionThrown()
+
+        when:
+        buildBeanDefinition('test.Test', """
+package test;
+
+@io.micronaut.http.annotation.Controller("/test")
+class Test {
+
+    @javax.ws.rs.Path("/{user_id}")
+    @javax.ws.rs.GET
+    void test(@javax.ws.rs.PathParam("user_id") String userId) {}
+}
+""")
+
+        then:
+        noExceptionThrown()
+    }
+
+
+}

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
@@ -27,11 +27,9 @@ class InterfaceSpec extends Specification {
         then:
         response.status() == HttpStatus.OK
         response.body() == "hello"
-    }
 
-    void 'test JAX-RS controller works with interface and with no @Path on method'() {
         when:
-        def response = rootClient.toBlocking().exchange("/api/interface/test", String.class)
+        response = rootClient.toBlocking().exchange("/api/interface/test", String.class)
 
         then:
         response.status() == HttpStatus.OK
@@ -45,11 +43,9 @@ class InterfaceSpec extends Specification {
         then:
         response.status() == HttpStatus.OK
         response.body() == "hello"
-    }
 
-    void 'test JAX-RS client works with interface and with no @Path on method'() {
         when:
-        def response = interfaceClient.noPathPing()
+        response = interfaceClient.noPathPing()
 
         then:
         response.status() == HttpStatus.OK


### PR DESCRIPTION
I had to deal with another Jaxrs project. And I noticed that workaround for compile-time path parameter validation (https://github.com/micronaut-projects/micronaut-jaxrs/commit/b6224444de156b998c709ea518de7a71c7751224) does not work ok.

JaxRsTypeElementVisitor has to be `ISOLATING` to make path param validation truly work. I also added Unit tests for that and fixed some cases when `@Controller` is mixed with Jaxrs annotations (although I hope users don't mix and match).