### PR TITLE
Fix cases when controllers have just javax.ws.rs.Path annotation

### DIFF
--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DeleteAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DeleteAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -42,7 +43,7 @@ public class DeleteAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Delete.class).build()
+                AnnotationValue.builder(Delete.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/GetAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/GetAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -32,6 +33,7 @@ import java.util.List;
  * @since 1.0.0
  */
 public class GetAnnotationMapper implements NamedAnnotationMapper {
+
     @Nonnull
     @Override
     public String getName() {
@@ -41,7 +43,7 @@ public class GetAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Get.class).build()
+                AnnotationValue.builder(Get.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeadAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeadAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Head;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -42,7 +43,7 @@ public class HeadAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Head.class).build()
+                AnnotationValue.builder(Head.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
@@ -81,7 +81,7 @@ public class HttpMethodMapper implements NamedAnnotationMapper {
             }
 
             return Collections.singletonList(
-                   builder.build()
+                   builder.value(UriMapping.DEFAULT_URI).build()
             );
         }
         return Collections.emptyList();

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.jaxrs.processor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.http.annotation.UriMapping;
@@ -49,6 +50,12 @@ public class JaxRsTypeElementVisitor implements TypeElementVisitor<Object, Objec
     @Override
     public int getOrder() {
         return POSITION; // higher priority to ensure mutations visible
+    }
+
+    @NonNull
+    @Override
+    public VisitorKind getVisitorKind() {
+        return VisitorKind.ISOLATING;
     }
 
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
@@ -17,9 +17,6 @@ package io.micronaut.jaxrs.processor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.http.annotation.Controller;
-import io.micronaut.http.annotation.HttpMethodMapping;
-import io.micronaut.http.annotation.UriMapping;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
@@ -87,30 +84,11 @@ public class JaxRsTypeElementVisitor implements TypeElementVisitor<Object, Objec
                         }
                     }
                 }
-
-            }
-
-            if (element.hasDeclaredAnnotation(Path.class) || hasAnnotationOnDeclaredMetadata(element, Path.class)) {
-                element.annotate(HttpMethodMapping.class, builder ->
-                        builder.value(element.stringValue(Path.class).orElse(UriMapping.DEFAULT_URI))
-                );
-            } else {
-                element.annotate(HttpMethodMapping.class, builder ->
-                        builder.value(UriMapping.DEFAULT_URI)
-                );
             }
         }
-
     }
 
     private List<Class<? extends Annotation>> getUnsupportedParameterAnnotations() {
         return Arrays.asList(MatrixParam.class, BeanParam.class);
-    }
-
-    private boolean hasAnnotationOnDeclaredMetadata(MethodElement element, Class<? extends Annotation> annotation) {
-        return (element.getAnnotationMetadata() instanceof AnnotationMetadataHierarchy &&
-                ((AnnotationMetadataHierarchy) element.getAnnotationMetadata())
-                        .getDeclaredMetadata()
-                        .hasAnnotation(annotation));
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/OptionsAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/OptionsAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Options;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -42,7 +43,7 @@ public class OptionsAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Options.class).build()
+                AnnotationValue.builder(Options.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
@@ -16,6 +16,8 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -25,16 +27,13 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * This mapper is enabled just because we want to trigger bean definition writer
- * when only @javax.ws.rs.Path annotation is present on class.
- *
- * Actual mapping of JAX-RS {@code Path} annotation to Micronaut's version
- * is done in {@link JaxRsTypeElementVisitor}.
+ * Maps the JAX-RS {@code Path} annotation to Micronaut's version.
  *
  * @author graemerocher
  * @since 1.0.0
  */
 public class PathAnnotationMapper implements NamedAnnotationMapper {
+
     @Nonnull
     @Override
     public String getName() {
@@ -43,6 +42,8 @@ public class PathAnnotationMapper implements NamedAnnotationMapper {
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-        return Collections.emptyList();
+        final AnnotationValueBuilder<HttpMethodMapping> builder = AnnotationValue.builder(HttpMethodMapping.class);
+        annotation.stringValue().ifPresent(builder::value);
+        return Collections.singletonList(builder.build());
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
@@ -16,8 +16,6 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.AnnotationValueBuilder;
-import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -27,7 +25,11 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Maps the JAX-RS {@code Path} annotation to Micronaut's version.
+ * This mapper is enabled just because we want to trigger bean definition writer
+ * when only @javax.ws.rs.Path annotation is present on class.
+ *
+ * Actual mapping of JAX-RS {@code Path} annotation to Micronaut's version
+ * is done in {@link JaxRsTypeElementVisitor}.
  *
  * @author graemerocher
  * @since 1.0.0
@@ -41,8 +43,6 @@ public class PathAnnotationMapper implements NamedAnnotationMapper {
 
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
-        final AnnotationValueBuilder<HttpMethodMapping> builder = AnnotationValue.builder(HttpMethodMapping.class);
-        annotation.stringValue().ifPresent(builder::value);
-        return Collections.singletonList(builder.build());
+        return Collections.emptyList();
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PostAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PostAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -41,7 +42,7 @@ public class PostAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Post.class).build()
+                AnnotationValue.builder(Post.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PutAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PutAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.annotation.Put;
+import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
@@ -41,7 +42,7 @@ public class PutAnnotationMapper implements NamedAnnotationMapper {
     @Override
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         return Collections.singletonList(
-                AnnotationValue.builder(Put.class).build()
+                AnnotationValue.builder(Put.class).value(UriMapping.DEFAULT_URI).build()
         );
     }
 }

--- a/jaxrs-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/jaxrs-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -1,4 +1,4 @@
-#io.micronaut.jaxrs.processor.PathAnnotationMapper
+io.micronaut.jaxrs.processor.PathAnnotationMapper
 io.micronaut.jaxrs.processor.GetAnnotationMapper
 io.micronaut.jaxrs.processor.ContextAnnotationMapper
 io.micronaut.jaxrs.processor.PostAnnotationMapper

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
@@ -4,7 +4,7 @@ package io.micronaut.jaxrs.runtime.core
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
-import io.micronaut.jaxrs.runtime.InterfaceResourceClient
+
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 
@@ -17,21 +17,9 @@ class InterfaceSpec extends Specification {
     @Client("/")
     RxHttpClient rootClient
 
-    @Inject
-    InterfaceResourceClient interfaceClient
-
     void 'test JAX-RS controller works with interface'() {
         when:
         def response = rootClient.toBlocking().exchange("/api/interface/test/ping/hello", String.class)
-
-        then:
-        response.status() == HttpStatus.OK
-        response.body() == "hello"
-    }
-
-    void 'test JAX-RS client works with interface'() {
-        when:
-        def response = interfaceClient.ping("hello")
 
         then:
         response.status() == HttpStatus.OK

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.jaxrs.runtime.core
+
+
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.RxHttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.jaxrs.runtime.InterfaceResourceClient
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+class InterfaceSpec extends Specification {
+
+    @Inject
+    @Client("/")
+    RxHttpClient rootClient
+
+    @Inject
+    InterfaceResourceClient interfaceClient
+
+    void 'test JAX-RS controller works with interface'() {
+        when:
+        def response = rootClient.toBlocking().exchange("/api/interface/test/ping/hello", String.class)
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body() == "hello"
+    }
+
+    void 'test JAX-RS client works with interface'() {
+        when:
+        def response = interfaceClient.ping("hello")
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body() == "hello"
+    }
+
+}

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/InterfaceSpec.groovy
@@ -4,7 +4,7 @@ package io.micronaut.jaxrs.runtime.core
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
-
+import io.micronaut.jaxrs.runtime.InterfaceResourceClient
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Specification
 
@@ -17,6 +17,9 @@ class InterfaceSpec extends Specification {
     @Client("/")
     RxHttpClient rootClient
 
+    @Inject
+    InterfaceResourceClient interfaceClient
+
     void 'test JAX-RS controller works with interface'() {
         when:
         def response = rootClient.toBlocking().exchange("/api/interface/test/ping/hello", String.class)
@@ -24,6 +27,33 @@ class InterfaceSpec extends Specification {
         then:
         response.status() == HttpStatus.OK
         response.body() == "hello"
+    }
+
+    void 'test JAX-RS controller works with interface and with no @Path on method'() {
+        when:
+        def response = rootClient.toBlocking().exchange("/api/interface/test", String.class)
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body() == "noPath"
+    }
+
+    void 'test JAX-RS client works with interface'() {
+        when:
+        def response = interfaceClient.ping("hello")
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body() == "hello"
+    }
+
+    void 'test JAX-RS client works with interface and with no @Path on method'() {
+        when:
+        def response = interfaceClient.noPathPing()
+
+        then:
+        response.status() == HttpStatus.OK
+        response.body() == "noPath"
     }
 
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResource.java
@@ -1,0 +1,19 @@
+package io.micronaut.jaxrs.runtime;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import io.micronaut.http.HttpResponse;
+
+public interface InterfaceResource {
+
+    @GET
+    @Path("/ping/{v}")
+    @Produces("text/plain")
+    @Consumes("text/plain")
+    HttpResponse<String> ping(@PathParam("v") String value);
+
+}

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResource.java
@@ -16,4 +16,9 @@ public interface InterfaceResource {
     @Consumes("text/plain")
     HttpResponse<String> ping(@PathParam("v") String value);
 
+    @GET
+    @Produces("text/plain")
+    @Consumes("text/plain")
+    HttpResponse<String> noPathPing();
+
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceClient.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceClient.java
@@ -1,8 +1,0 @@
-package io.micronaut.jaxrs.runtime;
-
-import io.micronaut.http.client.annotation.Client;
-
-@Client("/api/interface/test")
-public interface InterfaceResourceClient extends InterfaceResource {
-
-}

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceClient.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceClient.java
@@ -1,0 +1,8 @@
+package io.micronaut.jaxrs.runtime;
+
+import io.micronaut.http.client.annotation.Client;
+
+@Client("/api/interface/test")
+public interface InterfaceResourceClient extends InterfaceResource {
+
+}

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceImpl.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceImpl.java
@@ -12,4 +12,9 @@ public class InterfaceResourceImpl implements InterfaceResource {
         return HttpResponse.ok(value);
     }
 
+    @Override
+    public HttpResponse<String> noPathPing() {
+        return HttpResponse.ok("noPath");
+    }
+
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceImpl.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/InterfaceResourceImpl.java
@@ -1,0 +1,15 @@
+package io.micronaut.jaxrs.runtime;
+
+import javax.ws.rs.Path;
+
+import io.micronaut.http.HttpResponse;
+
+@Path("/interface/test")
+public class InterfaceResourceImpl implements InterfaceResource {
+
+    @Override
+    public HttpResponse<String> ping(String value) {
+        return HttpResponse.ok(value);
+    }
+
+}


### PR DESCRIPTION
I stumbled onto another issue. When only `@Path` is present on a class that implements some interface, bean definition is not written and controller is not created. This is an example of such usage:
```
interface TestService {
    @javax.ws.rs.GET
    @javax.ws.rs.Path("/foo")
    public String test();
}
@Path("/rest")
class Test implements TestService {
    @Override
    public String test() {
        return "ok";
    }
}
```

I found out that if I enable `PathAnnotationMapper.java` bean definition is written and such use cases works.  If there is any better way to do this, please let me know. 