### PR TITLE
annotate jackrs-processor classes as internal

### DIFF
--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ApplicationPathAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ApplicationPathAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -33,6 +34,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class ApplicationPathAnnotationMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ConsumesMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ConsumesMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Consumes;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class ConsumesMapper implements NamedAnnotationMapper {
 
     private static final String[] JAX_RS_DEFAULT_VALUE = new String[] { "*/*" };

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/CookieParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/CookieParamMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.CookieValue;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class CookieParamMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DefaultValueMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DefaultValueMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class DefaultValueMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DeleteAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/DeleteAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class DeleteAnnotationMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/FormParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/FormParamMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class FormParamMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/GetAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/GetAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class GetAnnotationMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeadAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeadAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Head;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class HeadAnnotationMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeaderParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HeaderParamMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class HeaderParamMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.annotation.*;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -34,6 +35,7 @@ import java.util.Locale;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class HttpMethodMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/JaxRsTypeElementVisitor.java
@@ -26,6 +26,7 @@ import javax.ws.rs.HttpMethod;
 import javax.ws.rs.MatrixParam;
 import javax.ws.rs.Path;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.http.annotation.Controller;
@@ -45,6 +46,7 @@ import javax.ws.rs.core.SecurityContext;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class JaxRsTypeElementVisitor implements TypeElementVisitor<Object, Object> {
 
     public static final int POSITION = 200;

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/OptionsAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/OptionsAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Options;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class OptionsAnnotationMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathAnnotationMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.HttpMethodMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class PathAnnotationMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PathParamMapper.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.List;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 
 import io.micronaut.core.annotation.AnnotationValue;
@@ -33,6 +34,7 @@ import io.micronaut.inject.visitor.VisitorContext;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class PathParamMapper implements NamedAnnotationMapper {
 
     @NonNull

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PostAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PostAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class PostAnnotationMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ProducesMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/ProducesMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class ProducesMapper implements NamedAnnotationMapper {
 
     private static final String[] JAX_RS_DEFAULT_VALUE = new String[] { "*/*" };

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PutAnnotationMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/PutAnnotationMapper.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.Put;
 import io.micronaut.http.annotation.UriMapping;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0.0
  */
+@Internal
 public class PutAnnotationMapper implements NamedAnnotationMapper {
     @NonNull
     @Override

--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/QueryParamMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/QueryParamMapper.java
@@ -17,6 +17,7 @@ package io.micronaut.jaxrs.processor;
 
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
@@ -32,6 +33,7 @@ import java.util.List;
  * @author graemerocher
  * @since 1.0
  */
+@Internal
 public class QueryParamMapper implements NamedAnnotationMapper {
     @NonNull
     @Override


### PR DESCRIPTION
Annotate classes in `jackrs-processor` module as internal

https://github.com/micronaut-projects/micronaut-jaxrs/pull/149#issuecomment-922707515

> these are internal classes, since they are part of the compiler plugin not the public API