### PR TITLE
Attempt to fix Sonar security issue with cookies

### DIFF
--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/CookieRequestArgumentBinder.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/CookieRequestArgumentBinder.java
@@ -26,6 +26,7 @@ import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
 import jakarta.inject.Singleton;
 import javax.ws.rs.core.Cookie;
 import java.util.Optional;
+import javax.ws.rs.core.NewCookie;
 
 /**
  * Argument binder for handling cookies.
@@ -50,7 +51,7 @@ public class CookieRequestArgumentBinder implements TypedRequestArgumentBinder<C
                 .findCookie(context.getAnnotationMetadata().stringValue(CookieValue.class)
                         .orElse(context.getArgument().getName())).orElse(null);
         if (cookie != null) {
-            Cookie c = new Cookie(cookie.getName(), cookie.getValue(), cookie.getPath(), cookie.getDomain());
+            Cookie c = new NewCookie(cookie.getName(), cookie.getValue(), cookie.getPath(), cookie.getDomain(), null, (int) cookie.getMaxAge(), cookie.isSecure(), cookie.isHttpOnly());
             return () -> Optional.of(c);
         } else {
             return BindingResult.EMPTY;

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeaderClient.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeaderClient.java
@@ -19,6 +19,12 @@ public interface HeaderClient {
     String cookie(@CookieParam("foo") Cookie cookie);
 
     @GET
+    @Path("/cookie-response")
+    @Consumes("text/plain")
+    @Produces("text/plain")
+    HttpResponse<String> cookieResponse(@CookieParam("foo") NewCookie cookie);
+
+    @GET
     @Path("/etag")
     @Consumes("text/plain")
     String etag(@HeaderParam(HttpHeaders.ETAG) EntityTag entityTag);

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
@@ -28,6 +28,16 @@ public class HeadersResource {
     }
 
     @GET
+    @Path("/cookie-response")
+    @Produces("text/plain")
+    public Response cookieResponse(@CookieParam("foo") NewCookie cookie) {
+        return Response.ok()
+            .entity(cookie.getValue())
+            .cookie(cookie)
+            .build();
+    }
+
+    @GET
     @Path("/etag")
     @Produces("text/plain")
     public Response etag(@HeaderParam(HttpHeaders.ETAG) EntityTag entityTag) {

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
 class HeadersTest {
@@ -113,6 +114,20 @@ class HeadersTest {
         assertEquals(
                 "bar",
                 result
+        );
+    }
+
+    @Test
+    void testSecureCookie() {
+        final HttpResponse<String> result = headerClient.cookieResponse(new NewCookie("foo", "bar", "/", "example.com", "", 0, true));
+
+        assertEquals(
+            "bar",
+            result.body()
+        );
+
+        assertTrue(
+            result.getCookie("foo").get().isSecure()
         );
     }
 


### PR DESCRIPTION
This is an attempt to fix this security issue:

https://sonarcloud.io/project/security_hotspots?id=micronaut-projects_micronaut-jaxrs&hotspots=AX8rpX66dUHpwG2Vx8vu

However, it is not really reproducible, since all the cookie attributes coming from the request are ignored by:

https://github.com/micronaut-projects/micronaut-core/blob/3.3.x/http-client-core/src/main/java/io/micronaut/http/client/bind/DefaultHttpClientBinderRegistry.java#L112-L113

So by the time we get the `NettyCookie` in the argument binder, it only has the name and value attributes.

Not sure if this is by design, or an actual issue in micronaut-core.