### PR TITLE
Update the JAX-RS 2.0 API doc links. Fixes #217

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ developers=Graeme Rocher
 githubCoreBranch=3.4.x
 bomProperty=micronautJaxrsVersion
 
-jaxrsapi=https://docs.oracle.com/javaee/7/api
+jaxrsapi=https://jakartaee.github.io/rest/apidocs/2.1.6/
 micronautapi=https://docs.micronaut.io/latest/api
 
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ developers=Graeme Rocher
 githubCoreBranch=3.4.x
 bomProperty=micronautJaxrsVersion
 
-jaxrsapi=https://jax-rs.github.io/apidocs/2.0
+jaxrsapi=https://docs.oracle.com/javaee/7/api
 micronautapi=https://docs.micronaut.io/latest/api
 
 org.gradle.caching=true

--- a/src/main/docs/guide/supportedApi.adoc
+++ b/src/main/docs/guide/supportedApi.adoc
@@ -14,67 +14,67 @@ Micronaut JAX-RS works by converting (at compilation time) a JAX-RS annotation d
 |===
 |JAX-RS Annotation|Target Annotation|Example
 
-|link:{jaxrsapi}/javax/ws/rs/Path.html[@Path]
-|link:{micronautapi}/io/micronaut/http/annotation/Controller.html[@Controller]
+|link:{jaxrsapi}javax/ws/rs/Path.html[@Path]
+|link:{micronautapi}http/annotation/Controller.html[@Controller]
 |`@Path("/foo")` // on type
 
-|link:{jaxrsapi}/javax/ws/rs/Path.html[@Path]
-|link:{micronautapi}/io/micronaut/http/annotation/UriMapping.html[@UriMapping]
+|link:{jaxrsapi}javax/ws/rs/Path.html[@Path]
+|link:{micronautapi}http/annotation/UriMapping.html[@UriMapping]
 |`@Path("/foo")` // on method
 
-|link:{jaxrsapi}/javax/ws/rs/HttpMethod.html[@HttpMethod]
-|link:{micronautapi}/io/micronaut/http/annotation/HttpMethodMapping.html[@HttpMethodMapping]
+|link:{jaxrsapi}javax/ws/rs/HttpMethod.html[@HttpMethod]
+|link:{micronautapi}http/annotation/HttpMethodMapping.html[@HttpMethodMapping]
 |`@HttpMethod("TRACE")`
 
-|link:{jaxrsapi}/javax/ws/rs/GET.html[@GET]
-|link:{micronautapi}/io/micronaut/http/annotation/Get.html[@Get]
+|link:{jaxrsapi}javax/ws/rs/GET.html[@GET]
+|link:{micronautapi}http/annotation/Get.html[@Get]
 |`@GET @Path("/foo/bar")`
 
-|link:{jaxrsapi}/javax/ws/rs/POST.html[@POST]
-|link:{micronautapi}/io/micronaut/http/annotation/Post.html[@Post]
+|link:{jaxrsapi}javax/ws/rs/POST.html[@POST]
+|link:{micronautapi}http/annotation/Post.html[@Post]
 |`@POST @Path("/foo/bar")`
 
-|link:{jaxrsapi}/javax/ws/rs/DELETE.html[@DELETE]
-|link:{micronautapi}/io/micronaut/http/annotation/Delete.html[@Delete]
+|link:{jaxrsapi}javax/ws/rs/DELETE.html[@DELETE]
+|link:{micronautapi}http/annotation/Delete.html[@Delete]
 |`@DELETE @Path("/foo/bar")`
 
-|link:{jaxrsapi}/javax/ws/rs/OPTIONS.html[@OPTIONS]
-|link:{micronautapi}/io/micronaut/http/annotation/Options.html[@Options]
+|link:{jaxrsapi}javax/ws/rs/OPTIONS.html[@OPTIONS]
+|link:{micronautapi}http/annotation/Options.html[@Options]
 |`@OPTIONS @Path("/foo/bar")`
 
-|link:{jaxrsapi}/javax/ws/rs/HEAD.html[@HEAD]
-|link:{micronautapi}/io/micronaut/http/annotation/Head.html[@Head]
+|link:{jaxrsapi}javax/ws/rs/HEAD.html[@HEAD]
+|link:{micronautapi}http/annotation/Head.html[@Head]
 |`@HEAD @Path("/foo/bar")`
 
-|link:{jaxrsapi}/javax/ws/rs/Consumes.html[@Consumes]
-|link:{micronautapi}/io/micronaut/http/annotation/Consumes.html[@Consumes]
+|link:{jaxrsapi}javax/ws/rs/Consumes.html[@Consumes]
+|link:{micronautapi}http/annotation/Consumes.html[@Consumes]
 |`@Consumes("application/json")`
 
-|link:{jaxrsapi}/javax/ws/rs/Produces.html[@Produces]
-|link:{micronautapi}/io/micronaut/http/annotation/Produces.html[@Produces]
+|link:{jaxrsapi}javax/ws/rs/Produces.html[@Produces]
+|link:{micronautapi}http/annotation/Produces.html[@Produces]
 |`@Produces("application/json")`
 
-|link:{jaxrsapi}/javax/ws/rs/PathParam.html[@PathParam]
-|link:{micronautapi}/io/micronaut/http/annotation/PathVariable.html[@PathVariable]
+|link:{jaxrsapi}javax/ws/rs/PathParam.html[@PathParam]
+|link:{micronautapi}http/annotation/PathVariable.html[@PathVariable]
 |`@PathParam("foo")`
 
-|link:{jaxrsapi}/javax/ws/rs/CookieParam.html[@CookieParam]
-|link:{micronautapi}/io/micronaut/http/annotation/CookieValue.html[@CookieValue]
+|link:{jaxrsapi}javax/ws/rs/CookieParam.html[@CookieParam]
+|link:{micronautapi}http/annotation/CookieValue.html[@CookieValue]
 |`@CookieParam("myCookie")`
 
-|link:{jaxrsapi}/javax/ws/rs/HeaderParam.html[@HeaderParam]
-|link:{micronautapi}/io/micronaut/http/annotation/Header.html[@Header]
+|link:{jaxrsapi}javax/ws/rs/HeaderParam.html[@HeaderParam]
+|link:{micronautapi}http/annotation/Header.html[@Header]
 |`@HeaderParam("Content-Type")`
 
-|link:{jaxrsapi}/javax/ws/rs/QueryParam.html[@QueryParam]
-|link:{micronautapi}/io/micronaut/http/annotation/QueryValue.html[@QueryValue]
+|link:{jaxrsapi}javax/ws/rs/QueryParam.html[@QueryParam]
+|link:{micronautapi}http/annotation/QueryValue.html[@QueryValue]
 |`@QueryParam("myParam")`
 
-|link:{jaxrsapi}/javax/ws/rs/DefaultValue.html[@DefaultValue]
-|link:{micronautapi}/io/micronaut/http/annotation/Bindable.html[@Bindable(defaultValue="..")]
+|link:{jaxrsapi}javax/ws/rs/DefaultValue.html[@DefaultValue]
+|link:{micronautapi}http/annotation/Bindable.html[@Bindable(defaultValue="..")]
 |`@DefaultValue("example")`
 
-|link:{jaxrsapi}/javax/ws/rs/core/Context.html[@Context]
+|link:{jaxrsapi}javax/ws/rs/core/Context.html[@Context]
 |No equivalent. Injects a bean in to a parameter.
 |`@Context`
 


### PR DESCRIPTION
The former JAX-RS 2.0 API docs are offline permanently. Switch to the Oracle-hosted Java EE 7 docs.