### PR TITLE
Fixes for broken master branch

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: ['17']
-        graalvm: ['latest', 'dev']
+        graalvm: ['latest']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ managed-jaxrs-api = "3.1.0"
 
 micronaut-security = "4.0.0-SNAPSHOT"
 micronaut-serde = "2.0.0-SNAPSHOT"
+micronaut-validation = "4.0.0-SNAPSHOT"
 
 [libraries]
 managed-jaxrs-api = { module = "jakarta.ws.rs:jakarta.ws.rs-api", version.ref = "managed-jaxrs-api" }
@@ -11,3 +12,4 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 
 micronaut-security = { module = "io.micronaut.security:micronaut-security-bom", version.ref = "micronaut-security" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
+micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }

--- a/jaxrs-processor/build.gradle
+++ b/jaxrs-processor/build.gradle
@@ -7,10 +7,10 @@ dependencies {
 	implementation(mn.micronaut.core.processor)
 	implementation(libs.managed.jaxrs.api)
 
-	testAnnotationProcessor(mn.micronaut.validation)
+	testAnnotationProcessor(mnValidation.micronaut.validation.processor)
 	testImplementation(mn.micronaut.http.validation)
 	testImplementation(mn.micronaut.http.server)
 	testImplementation(mn.micronaut.inject.java.test)
-	testImplementation(mn.micronaut.validation)
+	testImplementation(mnValidation.micronaut.validation)
 	testImplementation(mn.micronaut.http.client)
 }

--- a/jaxrs-server-security/build.gradle
+++ b/jaxrs-server-security/build.gradle
@@ -8,13 +8,13 @@ dependencies {
 	implementation projects.jaxrsServer
     implementation(mnSecurity.micronaut.security)
 
-	testAnnotationProcessor(mn.micronaut.validation)
+	testAnnotationProcessor(mnValidation.micronaut.validation.processor)
+	testImplementation(mnValidation.micronaut.validation)
 	testAnnotationProcessor(mn.micronaut.inject.java)
 	testAnnotationProcessor projects.jaxrsProcessor
 	testAnnotationProcessor(mnSecurity.micronaut.security.annotations)
 
 	testImplementation(libs.managed.jaxrs.api)
-	testImplementation(mn.micronaut.validation)
 	testImplementation(mn.micronaut.http.client)
 	testImplementation(mn.micronaut.http.server.netty)
 	testImplementation(mnTest.micronaut.test.junit5)

--- a/jaxrs-server/build.gradle.kts
+++ b/jaxrs-server/build.gradle.kts
@@ -13,14 +13,14 @@ dependencies {
 
 	// for Java
 	testAnnotationProcessor(mn.micronaut.inject.java)
-	testAnnotationProcessor(mn.micronaut.validation)
+	testAnnotationProcessor(mnValidation.micronaut.validation.processor)
 	testAnnotationProcessor(projects.jaxrsProcessor)
 
 	testImplementation(projects.jaxrsProcessor)
     testImplementation(mnSerde.micronaut.serde.jackson)
 	testImplementation(mn.micronaut.http.server.netty)
 	testImplementation(mn.micronaut.http.client)
-	testImplementation(mn.micronaut.validation)
+	testImplementation(mnValidation.micronaut.validation)
 	testImplementation(mnTest.micronaut.test.junit5)
 	testRuntimeOnly(libs.junit.jupiter.engine)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'io.micronaut.build.shared.settings' version '6.1.1'
+    id 'io.micronaut.build.shared.settings' version '6.2.2'
 }
 
 rootProject.name = 'jaxrs-parent'
@@ -23,5 +23,6 @@ micronautBuild {
     addSnapshotRepository()
     importMicronautCatalog("micronaut-security")
     importMicronautCatalog("micronaut-serde")
+    importMicronautCatalog("micronaut-validation")
 }
 


### PR DESCRIPTION
modules that use `mn.micronaut.validation` as dependencies are now broken. I figured out bringing in the BOM. I tried fixing that on this module. Previously, 47 tests failed on master. Now there are 48 failures (the new one is around validation).

the other 47 broken tests still need to be investigated