### PR TITLE
getHeaderString was returning an empty string for missing headers

### DIFF
--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/JaxRsHttpHeaders.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/JaxRsHttpHeaders.java
@@ -16,6 +16,7 @@
 package io.micronaut.jaxrs.runtime.ext.bind;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.jaxrs.runtime.core.Weighted;
 import io.micronaut.jaxrs.runtime.ext.impl.CookieHeaderDelegate;
 import jakarta.ws.rs.core.Cookie;
@@ -59,7 +60,7 @@ public class JaxRsHttpHeaders implements HttpHeaders {
     @Override
     public String getHeaderString(String name) {
         List<String> all = httpHeaders.getAll(name);
-        if (all.isEmpty()) {
+        if (CollectionUtils.isEmpty(all)) {
             return null;
         } else {
             return String.join(",", all);

--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/JaxRsHttpHeaders.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/JaxRsHttpHeaders.java
@@ -58,7 +58,12 @@ public class JaxRsHttpHeaders implements HttpHeaders {
 
     @Override
     public String getHeaderString(String name) {
-        return String.join(",", httpHeaders.getAll(name));
+        List<String> all = httpHeaders.getAll(name);
+        if (all.isEmpty()) {
+            return null;
+        } else {
+            return String.join(",", all);
+        }
     }
 
     @Override

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
@@ -88,8 +88,8 @@ public class HeadersResource {
     @Produces("text/plain")
     public Response header(HttpHeaders httpHeaders) {
         final Response.ResponseBuilder ok = Response.ok();
-        String headerString = httpHeaders.getHeaderString("non-existent");
-        ok.entity(headerString == null ? "null" : "not-null");
+        String headerString = httpHeaders.getHeaderString("test-value");
+        ok.entity(headerString == null ? "null" : headerString);
         return ok.build();
     }
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersResource.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.core.Cookie;
@@ -79,6 +80,16 @@ public class HeadersResource {
                 ok.header(s, string);
             }
         });
+        return ok.build();
+    }
+
+    @GET
+    @Path("/header")
+    @Produces("text/plain")
+    public Response header(HttpHeaders httpHeaders) {
+        final Response.ResponseBuilder ok = Response.ok();
+        String headerString = httpHeaders.getHeaderString("non-existent");
+        ok.entity(headerString == null ? "null" : "not-null");
         return ok.build();
     }
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @MicronautTest
@@ -187,5 +188,14 @@ class HeadersTest {
                 "en",
                 acceptableLanguages.get(0).getLanguage()
         );
+    }
+
+    @Test
+    void testUnknownHeaderValueIsNull() {
+        final MutableHttpRequest<Object> request = HttpRequest.GET("/headers/header");
+        request.header(HttpHeaders.ACCEPT_LANGUAGE, "fr;q=0.7,en;q=0.9");
+        final HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
+
+        assertEquals("null", response.body());
     }
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/runtime/HeadersTest.java
@@ -194,8 +194,19 @@ class HeadersTest {
     void testUnknownHeaderValueIsNull() {
         final MutableHttpRequest<Object> request = HttpRequest.GET("/headers/header");
         request.header(HttpHeaders.ACCEPT_LANGUAGE, "fr;q=0.7,en;q=0.9");
-        final HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
 
+        final HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
         assertEquals("null", response.body());
+    }
+
+    @Test
+    void testKnownHeaderValueString() {
+        final MutableHttpRequest<Object> request = HttpRequest.GET("/headers/header");
+        request.header(HttpHeaders.ACCEPT_LANGUAGE, "fr;q=0.7,en;q=0.9");
+        request.header("test-value", "one");
+        request.header("test-value", "two");
+
+        final HttpResponse<String> response = httpClient.toBlocking().exchange(request, String.class);
+        assertEquals("one,two", response.body());
     }
 }


### PR DESCRIPTION
This is not as per the definition.
This change makes it return null when it it missing.

https://jakarta.ee/specifications/platform/8/apidocs/javax/ws/rs/core/httpheaders#getHeaderString-java.lang.String-

Fixes #203 