### PR TITLE
Add support for resolveTemplate and resolveTemplates

### DIFF
--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/core/JaxRsUriBuilder.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/core/JaxRsUriBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class JaxRsUriBuilder extends UriBuilder {
 
-    private final io.micronaut.http.uri.UriBuilder uriBuilder;
+    private io.micronaut.http.uri.UriBuilder uriBuilder;
 
     /**
      * Default constructor.
@@ -180,7 +180,8 @@ public class JaxRsUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder resolveTemplate(String name, Object value) {
-        throw new UnsupportedOperationException("Method resolveTemplate(..) not supported by implementation");
+        uriBuilder = io.micronaut.http.uri.UriBuilder.of(uriBuilder.expand(Map.of(name, value)));
+        return this;
     }
 
     @Override
@@ -195,7 +196,8 @@ public class JaxRsUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder resolveTemplates(Map<String, Object> templateValues) {
-        throw new UnsupportedOperationException("Method resolveTemplates(..) not supported by implementation");
+        uriBuilder = io.micronaut.http.uri.UriBuilder.of(uriBuilder.expand(templateValues));
+        return this;
     }
 
     @Override

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/JaxRsUriBuilderSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/JaxRsUriBuilderSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.jaxrs.runtime.core
+
+import spock.lang.Specification
+
+class JaxRsUriBuilderSpec extends Specification {
+
+    def 'resolve template encodes the value'() {
+        given:
+        def builder = JaxRsUriBuilder.fromPath("/person")
+
+        when:
+        def result = builder.path("/{name}").resolveTemplate("name", "Tim Yates").build()
+
+        then:
+        result.toString() == '/person/Tim%20Yates'
+    }
+
+    def 'resolve template accepts multiple values'() {
+        given:
+        def builder = JaxRsUriBuilder.fromPath("/person/{age}")
+        Map<String, Object> values = Map.of("name", "Tim Yates", "age", 43)
+
+        when:
+        def result = builder.path("/{name}").resolveTemplates(values).build()
+
+        then:
+        result.toString() == '/person/43/Tim%20Yates'
+    }
+}


### PR DESCRIPTION
This does not add support for the varients with encodeSlashInPath, nor the others. To support those, I believe we would need to rewrite this as the functionality differs from the core UriBuilder.

Unless requested, I'm not sure it's worth the extra work to do that at this time.

Fixes #247 