### PR TITLE
Update versions

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ spock = "2.3-groovy-4.0"
 
 micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
-micronaut-test = "4.2.1"
+micronaut-test = "4.4.0"
 micronaut-logging = "1.3.0"
 micronaut-security = "4.9.1"
 micronaut-serde = "2.10.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ managed-jaxrs-api = "3.1.0"
 groovy = "4.0.18"
 spock = "2.3-groovy-4.0"
 
-micronaut = "4.5.4"
+micronaut = "4.6.0"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.2.1"
 micronaut-logging = "1.3.0"


### PR DESCRIPTION
We deleted `io.micronaut.http.body.DynamicMessageBodyWriter` in  https://github.com/micronaut-projects/micronaut-core/pull/11002

However,  we use this class in JaxRsResponseMessageBodyWriter 

@dstepanov can you check it?