### PR TITLE
Prepare request for possible mutation in ContainerRequestFilter

### DIFF
--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
@@ -73,7 +73,6 @@ final class JaxRsFilters {
 
     @Nullable
     @RequestFilter
-    @Order(Ordered.LOWEST_PRECEDENCE)
     HttpResponse<?> filterRequest(MutableHttpRequest<?> request) throws IOException {
         if (requestFilters.isEmpty()) {
             return null;

--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
@@ -17,8 +17,6 @@ package io.micronaut.jaxrs.container;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.core.annotation.Order;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMethod;

--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
@@ -35,6 +35,7 @@ import io.micronaut.jaxrs.common.JaxRsGenericEntity;
 import io.micronaut.jaxrs.common.JaxRsMutableResponse;
 import io.micronaut.jaxrs.common.JaxRsResponse;
 import io.micronaut.jaxrs.common.JaxRsUtils;
+import io.micronaut.jaxrs.runtime.ext.bind.HttpHeadersBinder;
 import io.micronaut.web.router.RouteInfo;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseFilter;
@@ -72,13 +73,6 @@ final class JaxRsFilters {
 
     @Nullable
     @RequestFilter
-    @Order(Ordered.LOWEST_PRECEDENCE - 1)
-    HttpRequest<?> prepareRequest(MutableHttpRequest<?> request) {
-        return requestFilters.isEmpty() ? null : request;
-    }
-
-    @Nullable
-    @RequestFilter
     @Order(Ordered.LOWEST_PRECEDENCE)
     HttpResponse<?> filterRequest(MutableHttpRequest<?> request) throws IOException {
         if (requestFilters.isEmpty()) {
@@ -88,6 +82,7 @@ final class JaxRsFilters {
         if (!containerResponseFilters.isEmpty()) {
             request.setAttribute(REQUEST_CONTEXT_KEY, requestContext);
         }
+        request.setAttribute(HttpHeadersBinder.HEADERS_KEY, request.getHeaders());
         for (ContainerRequestFilter requestFilter : requestFilters) {
             requestFilter.filter(requestContext);
             Response response = requestContext.getResponse();

--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/container/JaxRsFilters.java
@@ -17,6 +17,8 @@ package io.micronaut.jaxrs.container;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMethod;
@@ -70,6 +72,14 @@ final class JaxRsFilters {
 
     @Nullable
     @RequestFilter
+    @Order(Ordered.LOWEST_PRECEDENCE - 1)
+    HttpRequest<?> prepareRequest(MutableHttpRequest<?> request) {
+        return requestFilters.isEmpty() ? null : request;
+    }
+
+    @Nullable
+    @RequestFilter
+    @Order(Ordered.LOWEST_PRECEDENCE)
     HttpResponse<?> filterRequest(MutableHttpRequest<?> request) throws IOException {
         if (requestFilters.isEmpty()) {
             return null;

--- a/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/HttpHeadersBinder.java
+++ b/jaxrs-server/src/main/java/io/micronaut/jaxrs/runtime/ext/bind/HttpHeadersBinder.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 public class HttpHeadersBinder implements TypedRequestArgumentBinder<HttpHeaders> {
 
     public static final Argument<HttpHeaders> TYPE = Argument.of(HttpHeaders.class);
+    public static final String HEADERS_KEY = HttpHeaders.class.getName();
 
     @Override
     public Argument<HttpHeaders> argumentType() {
@@ -43,6 +44,10 @@ public class HttpHeadersBinder implements TypedRequestArgumentBinder<HttpHeaders
 
     @Override
     public BindingResult<HttpHeaders> bind(ArgumentConversionContext<HttpHeaders> context, HttpRequest<?> source) {
+        Object jaxRxHeaders = source.getAttribute(HEADERS_KEY).orElse(null);
+        if (jaxRxHeaders instanceof io.micronaut.http.HttpHeaders httpHeaders) {
+            return () -> Optional.of(JaxRsHttpHeaders.forRequest(httpHeaders));
+        }
         return () -> Optional.of(JaxRsHttpHeaders.forRequest(source.getHeaders()));
     }
 }

--- a/jaxrs-servlet/src/test/java/io/micronaut/jaxrs/servlet/FilterHeaderMutationTest.java
+++ b/jaxrs-servlet/src/test/java/io/micronaut/jaxrs/servlet/FilterHeaderMutationTest.java
@@ -1,0 +1,44 @@
+package io.micronaut.jaxrs.servlet;
+
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.ext.Provider;
+import java.io.IOException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@MicronautTest
+public class FilterHeaderMutationTest {
+
+    @Test
+    void testHeadersCanBeMutated(@Client("/") HttpClient client) {
+        String result = client.toBlocking().retrieve("/headers/test");
+        Assertions.assertEquals("bar", result);
+    }
+
+    @Path("/headers/test")
+    public static class TestResource {
+
+        @GET
+        @Produces("text/plain")
+        public String get(HttpHeaders httpHeaders) {
+            String header = httpHeaders.getHeaderString("foo");
+            return header != null ? header : "Unknown";
+        }
+    }
+
+    @Provider
+    public static class TestFilter implements ContainerRequestFilter {
+        @Override
+        public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+            containerRequestContext.getHeaders().add("foo", "bar");
+        }
+    }
+}


### PR DESCRIPTION
Currently if you mutate headers in a ContainerRequestFilter it doesn't propagate the mutation to the injected headers of a resource. This is problematic. This PR stores the mutated headers in a request attribute which the binder uses downstream.