### PR TITLE
Delegate to ResponseBodyWriter where possible

### DIFF
--- a/jaxrs-client/src/main/java/io/micronaut/jaxrs/client/JaxRsConfiguration.java
+++ b/jaxrs-client/src/main/java/io/micronaut/jaxrs/client/JaxRsConfiguration.java
@@ -23,7 +23,6 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.Headers;
-import io.micronaut.core.type.MutableHeaders;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMessage;
 import io.micronaut.http.MediaType;
@@ -38,6 +37,7 @@ import io.micronaut.jaxrs.common.JaxRsMessageBodyReader;
 import io.micronaut.jaxrs.common.JaxRsMessageBodyReaderDefinition;
 import io.micronaut.jaxrs.common.JaxRsMessageBodyWriter;
 import io.micronaut.jaxrs.common.JaxRsUtils;
+import io.micronaut.jaxrs.common.JaxRsWriterInterceptorContextState;
 import jakarta.ws.rs.RuntimeType;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.ClientResponseFilter;
@@ -52,7 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -381,18 +380,18 @@ final class JaxRsConfiguration implements Configuration {
                 written.set(true);
             }
         } else {
-            new JaxRsInterceptedWrite<T>(writerInterceptors) {
+            new JaxRsInterceptedWrite<T, JaxRsWriterInterceptorContextState.ClassicState>(writerInterceptors) {
 
                 @Override
-                protected void writeToAfterInterception(Argument<Object> argument, MediaType mediaType, Object entity, MutableHeaders outgoingHeaders, OutputStream outputStream) {
+                protected void writeToAfterInterception(Argument<Object> argument, MediaType mediaType, JaxRsWriterInterceptorContextState.ClassicState state) {
                     io.micronaut.http.body.MessageBodyWriter<Object> writer = findWriter(argument, mediaType);
                     if (writer != null) {
-                        writer.writeTo(argument, mediaType, entity, mutableHttpMessage.getHeaders(), outputStream);
+                        writer.writeTo(argument, mediaType, state.getEntity(), mutableHttpMessage.getHeaders(), state.getOutputStream());
                         written.set(true);
                     }
                 }
 
-            }.intercept(bodyArgument, mediaType, body, mutableHttpMessage.getHeaders(), outputStream);
+            }.intercept(bodyArgument, mediaType, new JaxRsWriterInterceptorContextState.ClassicState(mutableHttpMessage.getHeaders(), body, outputStream));
         }
 
         if (written.get()) {

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsGenericEntityMessageBodyWriter.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsGenericEntityMessageBodyWriter.java
@@ -292,17 +292,23 @@ final class JaxRsGenericEntityMessageBodyWriter<T> implements ResponseBodyWriter
             if (writerInterceptorsRegistrations.isEmpty()) {
                 writeInner();
             } else {
-                new JaxRsInterceptedWrite<T, ByteBodyState>(writerInterceptorsRegistrations, nameBindingPredicate) {
+                try {
+                    new JaxRsInterceptedWrite<T, ByteBodyState>(writerInterceptorsRegistrations, nameBindingPredicate) {
 
-                    @Override
-                    protected void writeToAfterInterception(Argument<Object> argument,
-                                                            MediaType mediaType,
-                                                            ByteBodyState state) {
-                        ByteBodyState.this.argument = (Argument<T>) argument;
-                        ByteBodyState.this.mediaType = mediaType;
-                        writeInner();
-                    }
-                }.intercept(argument, mediaType, this);
+                        @Override
+                        protected void writeToAfterInterception(Argument<Object> argument,
+                                                                MediaType mediaType,
+                                                                ByteBodyState state) {
+                            ByteBodyState.this.argument = (Argument<T>) argument;
+                            ByteBodyState.this.mediaType = mediaType;
+                            writeInner();
+                        }
+                    }.intercept(argument, mediaType, this);
+                } catch (CodecException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new CodecException("Failed to run JAX-RS WriterInterceptor", e);
+                }
             }
             if (outputIntercepted) {
                 finishIntercepted();

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsGenericEntityMessageBodyWriter.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsGenericEntityMessageBodyWriter.java
@@ -20,16 +20,26 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.MutableHeaders;
+import io.micronaut.http.ByteBodyHttpResponse;
+import io.micronaut.http.ByteBodyHttpResponseWrapper;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.body.ByteBodyFactory;
+import io.micronaut.http.body.CloseableByteBody;
 import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.body.MessageBodyWriter;
+import io.micronaut.http.body.ResponseBodyWriter;
 import io.micronaut.http.codec.CodecException;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.WriterInterceptor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Optional;
@@ -43,7 +53,7 @@ import java.util.Optional;
  */
 @Internal
 @Singleton
-final class JaxRsGenericEntityMessageBodyWriter<T> implements MessageBodyWriter<GenericEntity<T>> {
+final class JaxRsGenericEntityMessageBodyWriter<T> implements ResponseBodyWriter<GenericEntity<T>> {
 
     private final JaxRsMessageBodyHandlerRegistry jaxRsMessageBodyHandlerRegistry;
     private final MessageBodyHandlerRegistry registry;
@@ -58,6 +68,11 @@ final class JaxRsGenericEntityMessageBodyWriter<T> implements MessageBodyWriter<
         this.registry = registry;
         this.writerInterceptorsRegistrations = writerInterceptorsRegistrations;
         this.nameBindingPredicate = nameBindingPredicate;
+    }
+
+    @Override
+    public boolean isBlocking() {
+        return true;
     }
 
     @Override
@@ -84,18 +99,16 @@ final class JaxRsGenericEntityMessageBodyWriter<T> implements MessageBodyWriter<
         if (writerInterceptorsRegistrations.isEmpty()) {
             write(argument, mediaType, entity, outgoingHeaders, outputStream);
         } else {
-            new JaxRsInterceptedWrite<T>(writerInterceptorsRegistrations, nameBindingPredicate) {
+            new JaxRsInterceptedWrite<T, JaxRsWriterInterceptorContextState.ClassicState>(writerInterceptorsRegistrations, nameBindingPredicate) {
 
                 @Override
                 protected void writeToAfterInterception(Argument<Object> argument,
                                                         MediaType mediaType,
-                                                        Object entity,
-                                                        MutableHeaders outgoingHeaders,
-                                                        OutputStream outputStream) {
-                    write(argument, mediaType, entity, outgoingHeaders, outputStream);
+                                                        JaxRsWriterInterceptorContextState.ClassicState state) {
+                    write(argument, mediaType, state.getEntity(), outgoingHeaders, state.getOutputStream());
                 }
 
-            }.intercept(argument, mediaType, entity, outgoingHeaders, outputStream);
+            }.intercept(argument, mediaType, new JaxRsWriterInterceptorContextState.ClassicState(outgoingHeaders, entity, outputStream));
         }
 
         if (delegateEntityStream != null) {
@@ -127,4 +140,206 @@ final class JaxRsGenericEntityMessageBodyWriter<T> implements MessageBodyWriter<
         }
     }
 
+    @Override
+    public @NonNull ByteBodyHttpResponse<?> write(@NonNull ByteBodyFactory bodyFactory, @NonNull HttpRequest<?> request, @NonNull MutableHttpResponse<GenericEntity<T>> httpResponse, @NonNull Argument<GenericEntity<T>> type, @NonNull MediaType mediaType, GenericEntity<T> genericEntity) throws CodecException {
+        var s = new ByteBodyState(bodyFactory, request, httpResponse, mediaType, genericEntity) {
+            // this implementation, instead of using the body field, tries to keep the whole
+            // ByteBodyHttpResponse for as long as possible.
+
+            ByteBodyHttpResponse<?> innerResponse;
+
+            @Override
+            void finishIntercepted() {
+                if (innerResponse != null) {
+                    body = innerResponse.byteBody().move();
+                    innerResponse.close();
+                }
+            }
+
+            @Override
+            <U> void writeInner0(ResponseBodyWriter<U> rbw, Argument<U> argument, U entity) {
+                if (outputIntercepted) {
+                    super.writeInner0(rbw, argument, entity);
+                } else {
+                    innerResponse = rbw.write(bodyFactory, request, (MutableHttpResponse<U>) httpResponse, argument, mediaType, entity);
+                }
+            }
+        };
+        s.run();
+        if (s.outputIntercepted) {
+            return ByteBodyHttpResponseWrapper.wrap(httpResponse, s.body);
+        } else {
+            return s.innerResponse;
+        }
+    }
+
+    @Override
+    public @NonNull CloseableByteBody writePiece(@NonNull ByteBodyFactory bodyFactory, @NonNull HttpRequest<?> request, @NonNull HttpResponse<?> response, @NonNull Argument<GenericEntity<T>> type, @NonNull MediaType mediaType, GenericEntity<T> genericEntity) throws CodecException {
+        var s = new ByteBodyState(bodyFactory, request, response, mediaType, genericEntity);
+        s.run();
+        return s.body;
+    }
+
+    /**
+     * {@link JaxRsWriterInterceptorContextState} implementation that handles
+     * {@link #getOutputStream()} lazily to avoid unnecessary buffering. Note that there is an
+     * anonymous subclass in
+     * {@link #write(ByteBodyFactory, HttpRequest, MutableHttpResponse, Argument, MediaType, GenericEntity)}.
+     */
+    non-sealed class ByteBodyState implements JaxRsWriterInterceptorContextState {
+        // write method parameters
+        final ByteBodyFactory bodyFactory;
+        final HttpRequest<?> request;
+        final HttpResponse<?> response;
+        MediaType mediaType;
+
+        /**
+         * Argument contained in the GenericEntity.
+         */
+        Argument<T> argument;
+
+        /**
+         * JAX-RS view of the response headers.
+         */
+        final MultivaluedMap<String, Object> headers;
+        T entity;
+
+        /**
+         * When {@code true}, {@link #getOutputStream()} or {@link #setOutputStream(OutputStream)}
+         * has been called, so we will have to transfer the downstream
+         * {@link io.micronaut.http.body.ByteBody} through an {@link OutputStream}.
+         */
+        boolean outputIntercepted = false;
+        // TODO: we can use https://github.com/micronaut-projects/micronaut-core/pull/11934 in core 4.10.x
+        /**
+         * Destination buffer that will be turned into the final
+         * {@link io.micronaut.http.body.ByteBody}.
+         */
+        ByteArrayOutputStream bufferStream;
+        /**
+         * Current stream for {@link #getOutputStream()}. Sometimes it's {@link #bufferStream},
+         * sometimes it's a wrapper around it, etc.
+         */
+        OutputStream outputStream;
+
+        /**
+         * {@link CloseableByteBody} from the downstream {@link ResponseBodyWriter}. At the end of
+         * {@link #run()}, this is replaced by the data from {@link #bufferStream} if applicable.
+         */
+        CloseableByteBody body;
+
+        ByteBodyState(ByteBodyFactory bodyFactory, HttpRequest<?> request, HttpResponse<?> response, MediaType mediaType, GenericEntity<T> genericEntity) {
+            this.bodyFactory = bodyFactory;
+            this.request = request;
+            this.response = response;
+            this.headers = new JaxRsObjectHeadersMultivaluedMap(response.getHeaders());
+            this.mediaType = mediaType;
+            if (genericEntity instanceof JaxRsGenericEntity<T> jaxRsGenericEntity) {
+                argument = jaxRsGenericEntity.asArgument();
+                ByteArrayOutputStream delegateEntityStream = jaxRsGenericEntity.getDelegateEntityStream();
+                if (delegateEntityStream != null) {
+                    outputIntercepted = true;
+                    bufferStream = delegateEntityStream;
+                    outputStream = delegateEntityStream;
+                }
+                OutputStream customEntityStream = jaxRsGenericEntity.getCustomEntityStream();
+                if (customEntityStream != null) {
+                    setOutputStream(customEntityStream);
+                }
+            } else {
+                argument = JaxRsArgumentUtil.from(genericEntity);
+            }
+            this.entity = genericEntity.getEntity();
+        }
+
+        @Override
+        public Object getEntity() {
+            return entity;
+        }
+
+        @Override
+        public void setEntity(Object entity) {
+            this.entity = (T) entity;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            if (!outputIntercepted) {
+                bufferStream = new ByteArrayOutputStream();
+                outputStream = bufferStream;
+                outputIntercepted = true;
+            }
+            return outputStream;
+        }
+
+        @Override
+        public void setOutputStream(OutputStream outputStream) {
+            if (!outputIntercepted) {
+                // this will probably remain empty, but that's what the caller wants if they didn't
+                // call getOutputStream first
+                bufferStream = new ByteArrayOutputStream();
+                outputIntercepted = true;
+            }
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public MultivaluedMap<String, Object> getHeaders() {
+            return headers;
+        }
+
+        final void run() {
+            if (writerInterceptorsRegistrations.isEmpty()) {
+                writeInner();
+            } else {
+                new JaxRsInterceptedWrite<T, ByteBodyState>(writerInterceptorsRegistrations, nameBindingPredicate) {
+
+                    @Override
+                    protected void writeToAfterInterception(Argument<Object> argument,
+                                                            MediaType mediaType,
+                                                            ByteBodyState state) {
+                        ByteBodyState.this.argument = (Argument<T>) argument;
+                        ByteBodyState.this.mediaType = mediaType;
+                        writeInner();
+                    }
+                }.intercept(argument, mediaType, this);
+            }
+            if (outputIntercepted) {
+                finishIntercepted();
+                try (InputStream is = body.toInputStream()) {
+                    is.transferTo(outputStream);
+                } catch (IOException e) {
+                    throw new CodecException("Failed to buffer wrapped body", e);
+                }
+                body = bodyFactory.adapt(bufferStream.toByteArray());
+            }
+        }
+
+        void finishIntercepted() {
+        }
+
+        final void writeInner() {
+            List<MediaType> mediaTypes = List.of(mediaType);
+            // JaxRs writers
+            Optional<MessageBodyWriter<T>> writer = jaxRsMessageBodyHandlerRegistry.findWriter(this.argument, mediaTypes);
+            if (writer.isEmpty()) {
+                // Micronaut HTTP writers
+                writer = registry.findWriter(this.argument, mediaTypes);
+            }
+            if (writer.isEmpty()) {
+                Optional<MessageBodyWriter<String>> stringWriter = registry.findWriter(Argument.STRING, mediaTypes);
+                if (stringWriter.isPresent()) {
+                    writeInner0(ResponseBodyWriter.wrap(stringWriter.get()), Argument.STRING, this.entity.toString());
+                } else {
+                    throw new CodecException("Could not find MessageBodyWriter for media type " + mediaType + " for argument " + this.argument);
+                }
+            } else {
+                writeInner0(ResponseBodyWriter.wrap(writer.get().createSpecific(argument)), argument, entity);
+            }
+        }
+
+        <U> void writeInner0(ResponseBodyWriter<U> rbw, Argument<U> argument, U entity) {
+            body = rbw.writePiece(bodyFactory, request, response, argument, mediaType, entity);
+        }
+    }
 }

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsInterceptedWrite.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsInterceptedWrite.java
@@ -33,6 +33,7 @@ import java.util.List;
  * The JAX-RS body write interceptor.
  *
  * @param <T> The type
+ * @param <S> The context state implementation
  * @author Denis Stepanov
  * @since 4.9.0
  */
@@ -104,6 +105,7 @@ public abstract class JaxRsInterceptedWrite<T, S extends JaxRsWriterInterceptorC
      *
      * @param argument        The argument
      * @param mediaType       The media type
+     * @param state           The state (same as passed into {@link #intercept})
      */
     protected abstract void writeToAfterInterception(@NonNull Argument<Object> argument,
                                                      @NonNull MediaType mediaType,

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsInterceptedWrite.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsInterceptedWrite.java
@@ -20,13 +20,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.type.MutableHeaders;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.codec.CodecException;
 import jakarta.ws.rs.ext.WriterInterceptor;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -39,7 +37,7 @@ import java.util.List;
  * @since 4.9.0
  */
 @Internal
-public abstract class JaxRsInterceptedWrite<T> {
+public abstract class JaxRsInterceptedWrite<T, S extends JaxRsWriterInterceptorContextState> {
 
     private final List<BeanRegistration<WriterInterceptor>> writerInterceptorsRegistrations;
     private final NameBindingPredicate nameBindingPredicate;
@@ -63,16 +61,13 @@ public abstract class JaxRsInterceptedWrite<T> {
 
     public final void intercept(@NonNull Argument<T> type,
                                 @NonNull MediaType mediaType,
-                                T entity,
-                                @NonNull MutableHeaders outgoingHeaders,
-                                @NonNull OutputStream outputStream) throws CodecException {
+                                S state) throws CodecException {
         try {
             List<WriterInterceptor> writerInterceptors = writerInterceptorsRegistrations.stream()
                 .filter(br -> nameBindingPredicate.test(br.getBeanDefinition()))
                 .map(BeanRegistration::getBean)
                 .toList();
             Iterator<WriterInterceptor> iterator = writerInterceptors.iterator();
-            JaxRsMutableObjectHeadersMultivaluedMap httpHeaders = new JaxRsMutableObjectHeadersMultivaluedMap(outgoingHeaders);
             if (iterator.hasNext()) {
                 JaxRsWriterInterceptorContext context = new JaxRsWriterInterceptorContext(iterator,
                     ctx -> {
@@ -80,28 +75,23 @@ public abstract class JaxRsInterceptedWrite<T> {
                         Object newEntity = ctx.getEntity();
                         if (!argument.isInstance(newEntity)) {
                             newEntity = ConversionService.SHARED.convertRequired(newEntity, argument.getType());
+                            ctx.setEntity(newEntity);
                         }
                         writeToAfterInterception(
                             argument,
                             JaxRsUtils.convert(ctx.getMediaType()),
-                            newEntity,
-                            outgoingHeaders,
-                            ctx.getOutputStream());
+                            state);
                     },
                     type,
                     JaxRsUtils.convert(mediaType),
-                    httpHeaders,
-                    entity,
-                    outputStream
+                    state
                 );
                 iterator.next().aroundWriteTo(context);
             } else {
                 writeToAfterInterception(
                     (Argument<Object>) type,
                     mediaType,
-                    entity,
-                    outgoingHeaders,
-                    outputStream);
+                    state);
             }
         } catch (IOException e) {
             throw new JaxRsIOException(e);
@@ -114,14 +104,9 @@ public abstract class JaxRsInterceptedWrite<T> {
      *
      * @param argument        The argument
      * @param mediaType       The media type
-     * @param entity          The entity
-     * @param outgoingHeaders The headers
-     * @param outputStream    The output stream
      */
     protected abstract void writeToAfterInterception(@NonNull Argument<Object> argument,
                                                      @NonNull MediaType mediaType,
-                                                     Object entity,
-                                                     @NonNull MutableHeaders outgoingHeaders,
-                                                     @NonNull OutputStream outputStream);
+                                                     S state);
 
 }

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContext.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContext.java
@@ -38,23 +38,17 @@ final class JaxRsWriterInterceptorContext extends AbstractJaxRsInterceptorContex
 
     private final Iterator<WriterInterceptor> interceptors;
     private final IOProceedCallback interceptedSupplier;
-    private final MultivaluedMap<String, Object> headers;
-    private Object entity;
-    private OutputStream outputStream;
+    private final JaxRsWriterInterceptorContextState state;
 
     JaxRsWriterInterceptorContext(Iterator<WriterInterceptor> interceptors,
                                   IOProceedCallback interceptedCallback,
                                   Argument<?> argument,
                                   MediaType mediaType,
-                                  MultivaluedMap<String, Object> headers,
-                                  Object entity,
-                                  OutputStream outputStream) {
+                                  JaxRsWriterInterceptorContextState state) {
         super(argument, mediaType);
         this.interceptors = interceptors;
         this.interceptedSupplier = interceptedCallback;
-        this.headers = headers;
-        this.entity = entity;
-        this.outputStream = outputStream;
+        this.state = state;
     }
 
     @Override
@@ -68,27 +62,27 @@ final class JaxRsWriterInterceptorContext extends AbstractJaxRsInterceptorContex
 
     @Override
     public Object getEntity() {
-        return entity;
+        return state.getEntity();
     }
 
     @Override
     public void setEntity(Object entity) {
-        this.entity = entity;
+        state.setEntity(entity);
     }
 
     @Override
     public OutputStream getOutputStream() {
-        return outputStream;
+        return state.getOutputStream();
     }
 
     @Override
     public void setOutputStream(OutputStream os) {
-        this.outputStream = os;
+        state.setOutputStream(os);
     }
 
     @Override
     public MultivaluedMap<String, Object> getHeaders() {
-        return headers;
+        return state.getHeaders();
     }
 
     /**

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContextState.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContextState.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.jaxrs.common;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.MutableHeaders;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+
+import java.io.OutputStream;
+
+/**
+ * State carried through a chain of {@link jakarta.ws.rs.ext.WriterInterceptor} calls. This allows
+ * for lazily populating expensive-to-construct fields.
+ *
+ * @since 4.9.2
+ * @author Jonas Konrad
+ */
+@Internal
+public sealed interface JaxRsWriterInterceptorContextState permits JaxRsGenericEntityMessageBodyWriter.ByteBodyState, JaxRsWriterInterceptorContextState.ClassicState {
+    /**
+     * @see WriterInterceptorContext#getEntity()
+     */
+    Object getEntity();
+
+    /**
+     * @see WriterInterceptorContext#setEntity(Object)
+     */
+    void setEntity(Object entity);
+
+    /**
+     * @see WriterInterceptorContext#getOutputStream()
+     */
+    OutputStream getOutputStream();
+
+    /**
+     * @see WriterInterceptorContext#setOutputStream(OutputStream)
+     */
+    void setOutputStream(OutputStream outputStream);
+
+    /**
+     * @see WriterInterceptorContext#getHeaders()
+     */
+    MultivaluedMap<String, Object> getHeaders();
+
+    /**
+     * Implementation with simple fields.
+     */
+    final class ClassicState implements JaxRsWriterInterceptorContextState {
+        final MultivaluedMap<String, Object> headers;
+        Object entity;
+        OutputStream outputStream;
+
+        public ClassicState(MutableHeaders headers, Object entity, OutputStream outputStream) {
+            this.headers = new JaxRsMutableObjectHeadersMultivaluedMap(headers);
+            this.entity = entity;
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public Object getEntity() {
+            return entity;
+        }
+
+        @Override
+        public void setEntity(Object entity) {
+            this.entity = entity;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return outputStream;
+        }
+
+        @Override
+        public void setOutputStream(OutputStream outputStream) {
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public MultivaluedMap<String, Object> getHeaders() {
+            return headers;
+        }
+    }
+}

--- a/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContextState.java
+++ b/jaxrs-common/src/main/java/io/micronaut/jaxrs/common/JaxRsWriterInterceptorContextState.java
@@ -33,26 +33,31 @@ import java.io.OutputStream;
 public sealed interface JaxRsWriterInterceptorContextState permits JaxRsGenericEntityMessageBodyWriter.ByteBodyState, JaxRsWriterInterceptorContextState.ClassicState {
     /**
      * @see WriterInterceptorContext#getEntity()
+     * @return The response entity
      */
     Object getEntity();
 
     /**
      * @see WriterInterceptorContext#setEntity(Object)
+     * @param entity The response entity
      */
     void setEntity(Object entity);
 
     /**
      * @see WriterInterceptorContext#getOutputStream()
+     * @return The response stream
      */
     OutputStream getOutputStream();
 
     /**
      * @see WriterInterceptorContext#setOutputStream(OutputStream)
+     * @param outputStream The response stream
      */
     void setOutputStream(OutputStream outputStream);
 
     /**
      * @see WriterInterceptorContext#getHeaders()
+     * @return The response headers
      */
     MultivaluedMap<String, Object> getHeaders();
 

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/container/FileTest.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/container/FileTest.java
@@ -1,0 +1,53 @@
+package io.micronaut.jaxrs.container;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@MicronautTest
+@Property(name = "spec.name", value = "FileTest")
+class FileTest {
+
+    @Inject
+    @Client("/api/file")
+    HttpClient client;
+
+    @Inject
+    MyController controller;
+
+    @Test
+    void testFile() throws IOException {
+        controller.file = Files.createTempFile("jaxrs-FileTest", null).toFile();
+        try {
+            Files.writeString(controller.file.toPath(), "foo");
+            Assertions.assertEquals("foo", client.toBlocking().retrieve("/file"));
+        } finally {
+            controller.file.delete();
+        }
+    }
+
+    @Requires(property = "spec.name", value = "FileTest")
+    @Path("/file")
+    static class MyController {
+        File file;
+
+        @GET
+        @Path("/file")
+        @Produces("text/plain")
+        public File get() throws IOException {
+            return file;
+        }
+    }
+}


### PR DESCRIPTION
Since #539, all bodies are wrapped in a GenericEntity and must go through JaxRsGenericEntityMessageBodyWriter, which then delegates to the appropriate writer implementation for the type. However some of these writers do not support the full MessageBodyWriter interface and prefer to be called through the newer ResponseBodyWriter API, e.g. because they want to send a `not modified` response when appropriate.

This patch implements ResponseBodyWriter in JaxRsGenericEntityMessageBodyWriter. Since JAX-RS write interceptors potentially need to wrap the OutputStream, the interception code is adapted to transform the ByteBody to streams on demand by buffering the content. If there are no interceptors or if they don't access the OutputStream, the ByteBody or even ByteBodyHttpResponse is returned unmodified, which allows for streaming.

Fixes #561