### PR TITLE
JAX-RS without micronaut-reactor it fails

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,10 @@ micronaut-serde = "3.0.0-M1"
 micronaut-logging = "1.7.1"
 micronaut-servlet = "6.0.0-M1"
 micronaut-validation = "5.0.0-M1"
-micronaut-reactor = "4.0.0-M1"
 jakarta-jaxrs-tck = "4.0.1"
 
 [libraries]
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
-micronaut-reactor = { module = 'io.micronaut.reactor:micronaut-reactor-bom', version.ref = 'micronaut-reactor' }
 micronaut-security = { module = "io.micronaut.security:micronaut-security-bom", version.ref = "micronaut-security" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-servlet = { module = "io.micronaut.servlet:micronaut-servlet-bom", version.ref = "micronaut-servlet" }

--- a/jaxrs-client/build.gradle.kts
+++ b/jaxrs-client/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 dependencies {
     api(mn.micronaut.http)
     api(libs.managed.jaxrs.api)
-    implementation(mnReactor.micronaut.reactor)
     implementation(projects.micronautJaxrsCommon)
     implementation(mn.micronaut.http.client)
     implementation(mn.micronaut.buffer.netty)

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,5 @@ micronautBuild {
     importMicronautCatalog("micronaut-serde")
     importMicronautCatalog("micronaut-validation")
     importMicronautCatalog("micronaut-servlet")
-    importMicronautCatalog("micronaut-reactor")
 }
 


### PR DESCRIPTION
```
Execution failed for task ':micronaut-jaxrs-client:compileJava'.
> Compilation failed; see the compiler output below.
  /Users/sdelamo/.gradle/caches/modules-2/files-2.1/io.micronaut/micronaut-http-client/5.0.0-M6/a419f581ee80fc6a861c04121b0869341bc017ca/micronaut-http-client-5.0.0-M6.jar(/io/micronaut/http/client/netty/DefaultHttpClient.class): error: Cannot attach type annotations @org.jspecify.annotations.NonNull,@org.jspecify.annotations.Nullable to DefaultHttpClient.exchange:
    class file for reactor.core.publisher.Mono not found
```