### PR TITLE
Map the QUERY HTTP method to Micronaut's @Query

### DIFF
--- a/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
+++ b/jaxrs-processor/src/main/java/io/micronaut/jaxrs/processor/HttpMethodMapper.java
@@ -46,6 +46,9 @@ import java.util.Locale;
  */
 @Internal
 public class HttpMethodMapper implements NamedAnnotationMapper {
+    private static final String QUERY_METHOD = "QUERY";
+    private static final String QUERY_ANNOTATION = "io.micronaut.http.annotation.Query";
+
     @NonNull
     @Override
     public String getName() {
@@ -67,7 +70,11 @@ public class HttpMethodMapper implements NamedAnnotationMapper {
                 case TRACE -> AnnotationValue.builder(Trace.class);
                 case OPTIONS -> AnnotationValue.builder(Options.class);
                 case HEAD -> AnnotationValue.builder(Head.class);
-                case CUSTOM, CONNECT -> AnnotationValue.builder(CustomHttpMethod.class).member("method", name);
+                // QUERY (RFC 10008) has its own annotation since Micronaut 5.2; the router does not match a QUERY
+                // request against a custom method route, so use it by name when it is available
+                default -> QUERY_METHOD.equals(name) && visitorContext.getClassElement(QUERY_ANNOTATION).isPresent()
+                    ? AnnotationValue.builder(QUERY_ANNOTATION)
+                    : AnnotationValue.builder(CustomHttpMethod.class).member("method", name);
             };
             return Collections.singletonList(
                 builder.value(UriMapping.DEFAULT_URI).build()

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
@@ -291,6 +291,45 @@ class Test {
         "WATCH"   | CustomHttpMethod | "/test"
     }
 
+    void "test QUERY http method mapping"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', """
+package test;
+
+import java.lang.annotation.*;
+
+@jakarta.ws.rs.Path("/test")
+class Test {
+
+    @QUERY
+    @jakarta.ws.rs.Path("/test")
+    String test() {
+        return "ok";
+    }
+}
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@jakarta.ws.rs.HttpMethod("query")
+@Documented
+@interface QUERY {
+}
+""")
+        def executableMethod = definition.getRequiredMethod("test")
+        // io.micronaut.http.annotation.Query only exists since Micronaut 5.2
+        def queryAnnotation = "io.micronaut.http.annotation.Query"
+        def queryAnnotationPresent = io.micronaut.core.reflect.ClassUtils.isPresent(queryAnnotation, getClass().classLoader)
+
+        expect:
+        executableMethod.stringValue(HttpMethodMapping).get() == '/test'
+        if (queryAnnotationPresent) {
+            assert executableMethod.hasStereotype(queryAnnotation)
+            assert !executableMethod.hasStereotype(CustomHttpMethod)
+        } else {
+            assert executableMethod.stringValue(CustomHttpMethod, "method").get() == "QUERY"
+        }
+    }
+
     void "test mapped annotation from interface"() {
         given:
         def definition = buildBeanDefinition('test.Test', """

--- a/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
+++ b/jaxrs-processor/src/test/groovy/io/micronaut/jaxrs/processor/HttpMethodAnnotationSpec.groovy
@@ -291,9 +291,7 @@ class Test {
         "WATCH"   | CustomHttpMethod | "/test"
     }
 
-    void "test QUERY http method mapping"() {
-        given:
-        def definition = buildBeanDefinition('test.Test', """
+    private static final String QUERY_RESOURCE = """
 package test;
 
 import java.lang.annotation.*;
@@ -314,7 +312,44 @@ class Test {
 @Documented
 @interface QUERY {
 }
+"""
+
+    void "test QUERY http method mapping maps to @Query when the annotation is available"() {
+        given:
+        // stands in for io.micronaut.http.annotation.Query, which only exists since Micronaut 5.2
+        def files = new JavaFiles()
+                .add("io.micronaut.http.annotation.Query", """
+package io.micronaut.http.annotation;
+
+import io.micronaut.context.annotation.AliasFor;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@HttpMethodMapping
+public @interface Query {
+    @AliasFor(annotation = HttpMethodMapping.class, member = "value")
+    @AliasFor(annotation = UriMapping.class, member = "value")
+    String value() default UriMapping.DEFAULT_URI;
+}
 """)
+                .add("test.Test", QUERY_RESOURCE)
+        def context = buildContext(files)
+        def definition = context.getBeanDefinition(context.getClassLoader().loadClass('test.Test'))
+        def executableMethod = definition.getRequiredMethod("test")
+
+        expect:
+        executableMethod.hasStereotype("io.micronaut.http.annotation.Query")
+        !executableMethod.hasStereotype(CustomHttpMethod)
+        executableMethod.stringValue(HttpMethodMapping).get() == '/test'
+
+        cleanup:
+        context?.close()
+    }
+
+    void "test QUERY http method mapping"() {
+        given:
+        def definition = buildBeanDefinition('test.Test', QUERY_RESOURCE)
         def executableMethod = definition.getRequiredMethod("test")
         // io.micronaut.http.annotation.Query only exists since Micronaut 5.2
         def queryAnnotation = "io.micronaut.http.annotation.Query"

--- a/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/MethodsSpec.groovy
+++ b/jaxrs-server/src/test/groovy/io/micronaut/jaxrs/runtime/core/MethodsSpec.groovy
@@ -35,4 +35,15 @@ class MethodsSpec extends Specification {
         where:
         method << [HttpMethod.PUT, HttpMethod.GET, HttpMethod.DELETE, HttpMethod.POST, HttpMethod.OPTIONS]
     }
+
+    void 'test QUERY method mapping'() {
+        given:
+        // HttpMethod.QUERY only exists since Micronaut 5.2, before that QUERY parses to CUSTOM
+        def response = client.toBlocking().exchange(HttpRequest.create(
+                HttpMethod.parse("QUERY"), "/api/test-method/query", "QUERY"
+        ).body('search'), Argument.STRING)
+
+        expect:
+        response.body() == 'query search'
+    }
 }

--- a/jaxrs-server/src/test/java/io/micronaut/jaxrs/container/TestResource.java
+++ b/jaxrs-server/src/test/java/io/micronaut/jaxrs/container/TestResource.java
@@ -2,10 +2,17 @@ package io.micronaut.jaxrs.container;
 
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Path("/test-method")
 public class TestResource {
@@ -39,6 +46,19 @@ public class TestResource {
     @Path("/options")
     public String options() {
         return "options";
+    }
+
+    @QUERY
+    @Path("/query")
+    public String query(String body) {
+        return "query " + body;
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("QUERY")
+    @Documented
+    public @interface QUERY {
     }
 
 }


### PR DESCRIPTION
Part of micronaut-projects/micronaut-core#13110 (moving the platform projects onto core 5.2).

## The problem

Core 5.2 added `HttpMethod.QUERY` for the RFC 10008 QUERY method (micronaut-projects/micronaut-core#12780), together with a `@io.micronaut.http.annotation.Query` route annotation. Against core 5.2 the build stops at `:micronaut-jaxrs-processor:compileJava`, because the `switch (httpMethod)` in `HttpMethodMapper` is no longer exhaustive.

A plain `default` branch that keeps producing `@CustomHttpMethod(method = "QUERY")` would compile, but a JAX-RS `@HttpMethod("QUERY")` resource would stop routing on 5.2. `DefaultRouter` files a `CUSTOM` route under its method name, while a QUERY request now parses to `HttpMethod.QUERY` and is only looked up among the `QUERY` routes. The request would get no match.

## The change

- `HttpMethodMapper` gets a `default` branch. It maps `QUERY` to `io.micronaut.http.annotation.Query` when that annotation is on the processor classpath. Everything else, and QUERY on core 5.1, still maps to `@CustomHttpMethod`. The annotation is referenced by name and `HttpMethod.QUERY` is not referenced, so this compiles and behaves as before on core 5.1.x.
- `HttpMethodAnnotationSpec` checks the mapping: `@Query` when it exists, `@CustomHttpMethod(method = "QUERY")` otherwise. A second test compiles a stand-in `io.micronaut.http.annotation.Query` next to the resource, so the `@Query` path is also covered when building on core 5.1.
- `MethodsSpec` sends a QUERY request with a body to a resource annotated `@HttpMethod("QUERY")`, on both core versions.

JAX-RS itself has no `@QUERY` annotation, so custom `@HttpMethod("QUERY")` annotations are the case covered.

## Testing

- **Core 5.1.12 (this branch):** `:micronaut-jaxrs-processor:check` and `:micronaut-jaxrs-server:check` pass, 64 and 58 tests. The QUERY request reaches the resource as a custom method.
- **Core 5.2.0 (catalog bumped locally):** the same two tasks pass, 64 and 58 tests. The full `./gradlew check --continue` otherwise matches a baseline of `5.1.x` on 5.1.12: common 7, servlet 4, server-security 1, TCK 2,764 tests (1,074 skipped), no failures.
- **Negative control on 5.2.0:** with only a `default -> @CustomHttpMethod` branch, the new `MethodsSpec` test fails with `Method Not Allowed`.

## Remaining for core 5.2 (needs a new `5.2.x` branch)

5.1.0 is released, so core 5.2 cannot land on `5.1.x`. Once a `5.2.x` branch at `5.2.0-SNAPSHOT` exists:

- Bump the catalog to `micronaut = "5.2.0"`. With this PR applied, `./gradlew check --continue` passes on 5.2.0 with no other source changes.
- Replace `AnnotationReflectionUtils.resolveGenericToArgument`, deprecated for removal in core 5.2, in `JaxRsArgumentUtil` and `JaxRsConfiguration`. The replacement is `io.micronaut.reflection.ReflectionArguments#resolveGenericToArgument` from the new `micronaut-reflection` module, which is 5.2 only.
- `DefaultHttpClient.setHandlerRegistry` (used in `JaxRsClientBuilder`) is also deprecated for removal in favour of the builder. But `DefaultHttpClientBuilder.handlerRegistry(...)` is package-private in core 5.2.0, so there is no public replacement yet. That needs a core change before the call can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
